### PR TITLE
Add C5 compatibility

### DIFF
--- a/alist-lib-core.scm
+++ b/alist-lib-core.scm
@@ -38,7 +38,8 @@
     (alist "The alist in which to set")
     (key "The key to set")
     (value "The value to associate with the key"))
-  (lambda (expression rename compare)
+  (er-macro-transformer
+   (lambda (expression rename compare)
     (match expression
       ((_ variable key value)
        (let ((%if (rename 'if))
@@ -49,7 +50,7 @@
              (%alist-prepend! (rename 'alist-prepend!)))
          `(,%if (,%null? ,variable)
                 (,%set! ,variable (,%list (,%cons ,key ,value)))
-                (,%alist-prepend! ,variable ,key ,value)))))))
+                (,%alist-prepend! ,variable ,key ,value))))))))
 
 (define alist-update!
   @("On analogy with hash-table-update!, descructively update an

--- a/alist-lib.egg
+++ b/alist-lib.egg
@@ -1,0 +1,8 @@
+((synopsis "SRFI-69-like library for alists")
+ (author "Peter Danenberg")
+ (category data)
+ (license "BSD")
+ (dependencies (hahn "0.9.3") matchable)
+ (test-dependencies test)
+ (component-options (csc-options "-X" "hahn"))
+ (components (extension alist-lib)))

--- a/alist-lib.scm
+++ b/alist-lib.scm
@@ -12,9 +12,14 @@
   alist-size
   alist-fold
   alist-set)
- (import scheme
-         chicken)
- (use matchable
-      srfi-1)
+ (import scheme)
+ (cond-expand
+   (chicken-4
+    (import chicken)
+    (use matchable srfi-1))
+   (chicken-5
+    (import
+      (except chicken.base alist-ref alist-update!)
+      matchable srfi-1)))
  (import-for-syntax matchable)
  (include "alist-lib-core.scm"))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,4 +1,6 @@
-(use alist-lib test)
+(cond-expand
+  (chicken-4 (use alist-lib test))
+  (chicken-5 (import alist-lib test)))
 
 (test
  14


### PR DESCRIPTION
This adds preliminary Chicken 5 support to alist-lib. I want to work on porting hahn-utils over, but this is necessary first. (It follows then that this doesn't generate docs in C5, yet. Will probably be doable with a custom build script once hahn-utils is ported).